### PR TITLE
prevent port 8080 conflict with Glassfish #8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.box_check_update = false
 
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 80, host: 8888
   # might be suboptimal to do sshd work in vagrant
 
   # Share an additional folder to the guest VM. The first argument is


### PR DESCRIPTION
Changing Vagrant port from 8080 to 8888 for #8.